### PR TITLE
Fix "global name 'idaapi' is not defined" plugin bug

### DIFF
--- a/uEmu.py
+++ b/uEmu.py
@@ -455,7 +455,7 @@ class uEmuCpuContextView(simplecustviewer_t):
             self.menu_cols3 = 3
             self.menu_update = 4
 
-            class Hooks(idaapi.UI_Hooks):
+            class Hooks(UI_Hooks):
 
                 class PopupActionHandler(action_handler_t):
                     def __init__(self, owner, menu_id):
@@ -467,10 +467,10 @@ class uEmuCpuContextView(simplecustviewer_t):
                         self.owner.OnPopupMenu(self.menu_id)
 
                     def update(self, ctx):
-                        return idaapi.AST_ENABLE_ALWAYS
+                        return AST_ENABLE_ALWAYS
 
                 def __init__(self, form):
-                    idaapi.UI_Hooks.__init__(self)
+                    UI_Hooks.__init__(self)
                     self.form = form
 
                 def finish_populating_widget_popup(self, widget, popup):


### PR DESCRIPTION
**Issue**
When using the "Show CPU Context" option in uEmu plugin in IDA 7.2 I get the following error:
```
Traceback (most recent call last):
  File "C:/Program Files/IDA 7.2/plugins/uEmu.py", line 114, in activate
    self.action_handler.handle_menu_action(self.action_type)
  File "C:/Program Files/IDA 7.2/plugins/uEmu.py", line 1557, in handle_menu_action
    [x.handler() for x in self.MENU_ITEMS if x.action == action]
  File "C:/Program Files/IDA 7.2/plugins/uEmu.py", line 1754, in show_cpu_context
    self.cpuContextView.Create("uEmu CPU Context")
  File "C:/Program Files/IDA 7.2/plugins/uEmu.py", line 458, in Create
    class Hooks(idaapi.UI_Hooks):
NameError: global name 'idaapi' is not defined
```

**Cause**
Since the script doesn't use `import idaapi` can't access members like `idaapi.*`, change to using them directly.