### PR TITLE
Fix runtime error

### DIFF
--- a/uEmu.py
+++ b/uEmu.py
@@ -2056,19 +2056,15 @@ class uEmuPlugin(plugin_t, UI_Hooks):
     def close_windows(self):
         if self.cpuContextView is not None:
             self.cpuContextView.Close()
-            self.cpuContextView = None
 
         if self.cpuExtContextView is not None:
             self.cpuExtContextView.Close()
-            self.cpuExtContextView = None
 
         if self.stackView is not None:
             self.stackView.Close()
-            self.stackView = None
 
-        for viewid in self.memoryViews:
+        for viewid in list(self.memoryViews):
             self.memoryViews[viewid].Close()
-            self.memoryViews[viewid] = None
 
 def PLUGIN_ENTRY():
     return uEmuPlugin()


### PR DESCRIPTION
Fix runtime error caused by `close_windows()`,
```
Traceback (most recent call last):
  File "uEmu.py", line 111, in activate
    self.action_handler.handle_menu_action(self.action_type)
  File "uEmu.py", line 1743, in handle_menu_action
    [x.handler() for x in self.MENU_ITEMS if x.action == action]
  File "uEmu.py", line 1743, in <listcomp>
    [x.handler() for x in self.MENU_ITEMS if x.action == action]
  File "uEmu.py", line 1909, in emu_reset
    self.close_windows()
  File "uEmu.py", line 2067, in close_windows
    for viewid in self.memoryViews:
RuntimeError: dictionary changed size during iteration
```

`self.memoryViews[viewid]` will be deleted by its `OnClose()` callback, so we needs to get all the keys first instead of using an iterator, also since all the views will be cleaned by `OnClose()` callback, there's no need to assign `None` again in `close_windows()`.