### PR TITLE
use inequality operator for literal comparison

### DIFF
--- a/uEmu.py
+++ b/uEmu.py
@@ -493,7 +493,7 @@ class UEMU_HELPERS:
                     t = get_sreg(ea, "T")  # get T flag
                 else:
                     t = get_segreg(ea, 20) # get T flag
-                return t is not BADSEL and t is not 0
+                return t is not BADSEL and t != 0
             else:
                 return 0
         return UEMU_HELPERS.exec_on_main(handler, MFF_READ)


### PR DESCRIPTION
This fixes the warning I was getting in IDA. The warning is also mentioned [here](https://github.com/alexhude/uEmu/issues/43)